### PR TITLE
Allow perf_check to analyze branches with migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Benchmark options:
         --clear-cache                Call Rails.cache.clear before running benchmark
         --302-success                Consider HTTP 302 code a successful request
         --302-failure                Consider HTTP 302 code an unsuccessful request
+        --run-migrations             Run migrations up and down with branch
 
 Usage examples:
   Benchmark PostController#index against master

--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -73,12 +73,14 @@ class PerfCheck
 
   def run_migrations_up
     Bundler.with_clean_env{ `bundle exec rake db:migrate` }
+    Git.clean_db
   end
 
   def run_migrations_down
     Git.migrations_to_run_down.each do |version|
       Bundler.with_clean_env{ `bundle exec rake db:migrate:down VERSION=#{version}` }
     end
+    Git.clean_db
   end
 end
 

--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -72,25 +72,13 @@ class PerfCheck
   end
 
   def run_migrations_up
-    `bundle exec rake db:migrate`
+    Bundler.with_clean_env{ `bundle exec rake db:migrate` }
   end
 
   def run_migrations_down
-    current_migration_versions_not_on_master.each do |version|
-      `bundle exec rake db:migrate:down VERSION=#{version}`
+    Git.migrations_to_run_down.each do |version|
+      Bundler.with_clean_env{ `bundle exec rake db:migrate:down VERSION=#{version}` }
     end
-  end
-
-  def current_migration_versions_not_on_master
-    current_migration_filenames_not_on_master.map { |filename| file_name_to_migration_version(filename) }
-  end
-
-  def current_migration_filenames_not_on_master
-    %x{git diff origin/master --name-only --diff-filter=A db/migrate/}.split.reverse
-  end
-
-  def file_name_to_migration_version(filename)
-    File.basename(filename, '.rb').split('_').first
   end
 end
 

--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -72,13 +72,13 @@ class PerfCheck
   end
 
   def run_migrations_up
-    Bundler.with_clean_env{ `bundle exec rake db:migrate` }
+    Bundler.with_clean_env{ puts `bundle exec rake db:migrate` }
     Git.clean_db
   end
 
   def run_migrations_down
     Git.migrations_to_run_down.each do |version|
-      Bundler.with_clean_env{ `bundle exec rake db:migrate:down VERSION=#{version}` }
+      Bundler.with_clean_env{ puts `bundle exec rake db:migrate:down VERSION=#{version}` }
     end
     Git.clean_db
   end

--- a/lib/perf_check/config.rb
+++ b/lib/perf_check/config.rb
@@ -44,6 +44,10 @@ class PerfCheck
       config.caching = false
     end
 
+    opts.on('--run-migrations', 'Run migrations on the branch and unmigrate at the end') do
+      config[:run_migrations?] = true
+    end
+
     opts.on('--fail-fast', '-f', 'Bail immediately on non-200 HTTP response') do
       config[:fail_fast?] = true
     end

--- a/lib/perf_check/git.rb
+++ b/lib/perf_check/git.rb
@@ -76,5 +76,9 @@ class PerfCheck
       %x{git diff origin/master --name-only --diff-filter=A db/migrate/}.split.reverse
     end
     private_class_method :current_migrations_not_on_master
+
+    def self.clean_db
+      `git checkout db`
+    end
   end
 end

--- a/lib/perf_check/git.rb
+++ b/lib/perf_check/git.rb
@@ -67,5 +67,14 @@ class PerfCheck
         logger.fatal("Problem with git stash! Bailing...") && abort
       end
     end
+
+    def self.migrations_to_run_down
+      current_migrations_not_on_master.map { |filename| File.basename(filename, '.rb').split('_').first }
+    end
+
+    def self.current_migrations_not_on_master
+      %x{git diff origin/master --name-only --diff-filter=A db/migrate/}.split.reverse
+    end
+    private_class_method :current_migrations_not_on_master
   end
 end

--- a/test_app/Gemfile.lock
+++ b/test_app/Gemfile.lock
@@ -141,3 +141,6 @@ DEPENDENCIES
   test_engine!
   turbolinks
   uglifier (>= 1.3.0)
+
+BUNDLED WITH
+   1.11.2


### PR DESCRIPTION
Adds a new option to `perf_check` allowing it to analyze performance on branches that rely upon migrations. This allows `perf_check` to analyze branches that add or remove models and indexes.

When passed the `--run-migrations` flag, `perf_check` should run migrations up before starting the server. It should then run migrations down after finishing the performance run. It should be intelligent enough to handle a branch with migrations and a base branch with different migrations.