### PR TITLE
remove Object logger

### DIFF
--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -59,10 +59,10 @@ class PerfCheck
       test.cookie = options.cookie
 
       if options.diff
-        logger.info("Issuing #{test.resource}")
+        PerfCheck.logger.info("Issuing #{test.resource}")
       else
-        logger.info ''
-        logger.info("Benchmarking #{test.resource}:")
+        PerfCheck.logger.info ''
+        PerfCheck.logger.info("Benchmarking #{test.resource}:")
       end
 
       test.run(server, options)

--- a/lib/perf_check/callbacks.rb
+++ b/lib/perf_check/callbacks.rb
@@ -17,9 +17,9 @@ class PerfCheck
   def self.before_start_callbacks
     (@before_start_callbacks || []) + [
       proc {
-        logger.info("=" * 77)
-        logger.info("PERRRRF CHERRRK! Grab a ☕️  and don't touch your working tree (we automate git)")
-        logger.info("=" * 77)
+        PerfCheck.logger.info("=" * 77)
+        PerfCheck.logger.info("PERRRRF CHERRRK! Grab a ☕️  and don't touch your working tree (we automate git)")
+        PerfCheck.logger.info("=" * 77)
       }
     ]
   end

--- a/lib/perf_check/git.rb
+++ b/lib/perf_check/git.rb
@@ -11,7 +11,7 @@ class PerfCheck
     def self.checkout_reference(reference='master')
       checkout(reference)
       at_exit do
-        logger.info ''
+        PerfCheck.logger.info ''
         Git.checkout_current_branch(false)
       end
     end
@@ -21,11 +21,11 @@ class PerfCheck
     end
 
     def self.checkout(branch, bundle=true)
-      logger.info("Checking out #{branch} and bundling... ")
+      PerfCheck.logger.info("Checking out #{branch} and bundling... ")
       `git checkout #{branch} --quiet`
 
       unless $?.success?
-        logger.fatal("Problem with git checkout! Bailing...") && abort
+        PerfCheck.logger.fatal("Problem with git checkout! Bailing...") && abort
       end
 
       `git submodule update --quiet`
@@ -33,18 +33,18 @@ class PerfCheck
       if bundle
         Bundler.with_clean_env{ `bundle` }
         unless $?.success?
-          logger.fatal("Problem bundling! Bailing...") && abort
+          PerfCheck.logger.fatal("Problem bundling! Bailing...") && abort
         end
       end
     end
 
     def self.stash_if_needed
       if anything_to_stash?
-        logger.info("Stashing your changes... ")
+        PerfCheck.logger.info("Stashing your changes... ")
         system('git stash -q >/dev/null')
 
         unless $?.success?
-          logger.fatal("Problem with git stash! Bailing...") && abort
+          PerfCheck.logger.fatal("Problem with git stash! Bailing...") && abort
         end
 
         at_exit do
@@ -60,11 +60,11 @@ class PerfCheck
     end
 
     def self.pop
-      logger.info("Git stash applying...")
+      PerfCheck.logger.info("Git stash applying...")
       system('git stash pop -q')
 
       unless $?.success?
-        logger.fatal("Problem with git stash! Bailing...") && abort
+        PerfCheck.logger.fatal("Problem with git stash! Bailing...") && abort
       end
     end
 

--- a/lib/perf_check/logger.rb
+++ b/lib/perf_check/logger.rb
@@ -12,8 +12,3 @@ class PerfCheck
 
   def logger; self.class.logger; end
 end
-
-class Object
-  def self.logger; PerfCheck.logger; end
-  def logger; PerfCheck.logger; end
-end

--- a/lib/perf_check/server.rb
+++ b/lib/perf_check/server.rb
@@ -108,10 +108,10 @@ class PerfCheck
 
     def restart
       if !@running
-        logger.info("starting rails...")
+        PerfCheck.logger.info("starting rails...")
         start
       else
-        logger.info("re-starting rails...")
+        PerfCheck.logger.info("re-starting rails...")
         exit
         start
       end

--- a/lib/perf_check/test_case.rb
+++ b/lib/perf_check/test_case.rb
@@ -20,7 +20,7 @@ class PerfCheck
 
     def run(server, options)
       unless options.diff
-        logger.info("\t"+['request', 'latency', 'server rss', 'status', 'queries', 'profiler data'].map(&:underline).join("   "))
+        PerfCheck.logger.info("\t"+['request', 'latency', 'server rss', 'status', 'queries', 'profiler data'].map(&:underline).join("   "))
       end
 
       profiles = (@context == :reference) ? reference_profiles : this_profiles
@@ -40,9 +40,9 @@ class PerfCheck
               error_dump.write(profile.response_body)
             end
             error = sprintf("\t%2i:\tFAILED! (HTTP %d)", i, profile.response_code)
-            logger.fatal(error.red.bold)
-            logger.fatal("\t   The server responded with a non-2xx status for this request.")
-            logger.fatal("\t   The response has been written to tmp/perf_check/failed_request.html")
+            PerfCheck.logger.fatal(error.red.bold)
+            PerfCheck.logger.fatal("\t   The server responded with a non-2xx status for this request.")
+            PerfCheck.logger.fatal("\t   The response has been written to tmp/perf_check/failed_request.html")
             abort
           end
         end
@@ -65,13 +65,13 @@ class PerfCheck
           row = sprintf("\t%2i:\t  %.1fms   %4dMB\t  %s\t   %s\t   %s",
                         i, profile.latency, profile.server_memory,
                         profile.response_code, profile.query_count, profile.profile_url)
-          logger.info(row)
+          PerfCheck.logger.info(row)
         end
 
         profiles << profile
       end
 
-      logger.info '' unless options.diff # pretty!
+      PerfCheck.logger.info '' unless options.diff # pretty!
     end
 
     def this_latency


### PR DESCRIPTION
having
```ruby 
class Object		
 def self.logger; PerfCheck.logger; end		
 def logger; PerfCheck.logger; end		
end
```
was not allowing us to write to log/development.log. For example in the debugger when calling `logger` it was using `PerfCheck::Logger`
```ruby
[1] pry(#<HomeController>)> logger
=> #<Logger:0x007ff89ff392c0
 @default_formatter=#<Logger::Formatter:0x007ff89ff39298 @datetime_format=nil>,
 @formatter=#<Proc:0x007ff89ff39158@/usr/local/rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/perf_check-0.4.0/lib/perf_check/logger.rb:7>,
 @level=0,
 @logdev=
  #<Logger::LogDevice:0x007ff89ff39248
   @dev=#<IO:<STDERR>>,
   @filename=nil,
   @mutex=#<Logger::LogDevice::LogDeviceMutex:0x007ff89ff39220 @mon_count=0, @mon_mutex=#<Mutex:0x007ff89ff391d0>, @mon_owner=nil>,
   @shift_age=nil,
   @shift_size=nil>,
 @progname=nil>
```
after removing it we got
```
[1] pry(#<HomeController>)> logger
=> #<ActiveSupport::Logger:0x007feca7649150
 @default_formatter=#<Logger::Formatter:0x007feca76490d8 @datetime_format=nil>,
 @formatter=#<ActiveSupport::Logger::SimpleFormatter:0x007fec92a92aa0 @datetime_format=nil>,
 @level=0,
 @logdev=
  #<Logger::LogDevice:0x007feca7649088
   @dev=#<File:/Users/USER/app/log/development.log>,
   @filename=nil,
   @mutex=#<Logger::LogDevice::LogDeviceMutex:0x007feca7649060 @mon_count=0, @mon_mutex=#<Mutex:0x007feca7649010>, @mon_owner=nil>,
   @shift_age=nil,
   @shift_size=nil>,
 @progname=nil>
``` 