### PR TITLE
Restart the server before each test.

### DIFF
--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -69,7 +69,6 @@ class PerfCheck
   def run
     begin
       run_migrations_up if options.run_migrations?
-      server.restart
 
       if options.compare_paths?
         raise "Must have two paths" if test_cases.count != 2
@@ -113,9 +112,9 @@ class PerfCheck
     profile_test_case(reference_test)
   end
 
-  def profile_test_case(test, index = nil)
+  def profile_test_case(test)
     trigger_before_start_callbacks(test)
-    server.restart unless index == 0 || options.diff
+    server.restart
 
     test.cookie = options.cookie
 
@@ -130,8 +129,8 @@ class PerfCheck
   end
 
   def profile_requests
-    test_cases.each_with_index do |test, i|
-      profile_test_case(test, i)
+    test_cases.each do |test|
+      profile_test_case(test)
     end
   end
 

--- a/spec/perf_check_spec.rb
+++ b/spec/perf_check_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe PerfCheck do
     end
 
     it "should ensure to run migrations down if options.run_migrations?" do
+      perf_check.add_test_case('/xyz')
       perf_check.options[:run_migrations?] = true
 
       expect(perf_check).to receive(:run_migrations_up)


### PR DESCRIPTION
Change 1: restart on diff perf_checks
  Assumption: We were not restarting with the diff flag because we
  shouldn't need to restart to compare html output.

  I think this is a potentially dangerous assumption because there may
  be model-level changes that the view relies on. It seems safer to
  always restart.

Change 2: restart within loop
  Seperately, we were restarting before the loop and then in all but the
  first run of the loop. That's the same as running in each loop.