### PR TITLE
Fix intermittent spec failure.

### DIFF
--- a/spec/perf_check_bin_spec.rb
+++ b/spec/perf_check_bin_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "bin/perf_check" do
       log = out.lines.drop_while{ |x| x !~ /^=+ Results/ }
       expect(log.find{ |x| x =~ /reference: \d+\.\d+ms/ }).not_to be_nil
       expect(log.find{ |x| x =~ /your branch: \d+\.\d+ms/ }).not_to be_nil
-      expect(log.find{ |x| x =~ /change: [+-]\d+\.\d+ms/ }).not_to be_nil
+      expect(log.find{ |x| x =~ /change: -?\d+\.\d+ms/ }).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
This spec fails when the change is a positive number. The line looks
like
* ` change: 706.7ms (yours is 1.4x slower!!!)`
or
* `change: -560.0ms (yours is 1.3x faster!)`

So when the change is faster, the specs used to pass (it matched [+-]).
But when the change is slower, the line does not match the plus symbol.