### PR TITLE
Run migrations for each branch

### DIFF
--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -68,8 +68,6 @@ class PerfCheck
 
   def run
     begin
-      run_migrations_up if options.run_migrations?
-
       if options.compare_paths?
         raise "Must have two paths" if test_cases.count != 2
         profile_compare_paths_requests
@@ -84,7 +82,6 @@ class PerfCheck
         end
       end
     ensure
-      run_migrations_down if options.run_migrations?
       server.exit rescue nil
       if options.reference
         git.checkout_current_branch(false) rescue nil
@@ -114,6 +111,7 @@ class PerfCheck
 
   def profile_test_case(test)
     trigger_before_start_callbacks(test)
+    run_migrations_up if options.run_migrations?
     server.restart
 
     test.cookie = options.cookie
@@ -126,6 +124,8 @@ class PerfCheck
     end
 
     test.run(server, options)
+  ensure
+    run_migrations_down if options.run_migrations?
   end
 
   def profile_requests

--- a/spec/perf_check_spec.rb
+++ b/spec/perf_check_spec.rb
@@ -57,13 +57,19 @@ RSpec.describe PerfCheck do
     it "should ensure that anything stashed is popped"
 
     it "should not run migrations_up if !options.run_migrations?" do
+      perf_check.add_test_case('/xyz')
+
+      allow(perf_check.test_cases.first).to receive(:run)
       expect(perf_check).not_to receive(:run_migrations_up)
       perf_check.send :run
     end
 
     it "should run migrations if options.run_migrations" do
+      perf_check.add_test_case('/xyz')
       perf_check.options[:run_migrations?] = true
+      perf_check.options[:reference] = nil
 
+      allow(perf_check.test_cases.first).to receive(:run)
       expect(perf_check).to receive(:run_migrations_up)
       expect(perf_check).to receive(:run_migrations_down)
       perf_check.send :run
@@ -72,6 +78,7 @@ RSpec.describe PerfCheck do
     it "should ensure to run migrations down if options.run_migrations?" do
       perf_check.add_test_case('/xyz')
       perf_check.options[:run_migrations?] = true
+      perf_check.options[:reference] = nil
 
       expect(perf_check).to receive(:run_migrations_up)
       expect(perf_check).to receive(:run_migrations_down)


### PR DESCRIPTION
Rather than running migrations at the beginning (on the first branch)
and at the end (on the final branch), we want to run migrations up and
down on each branch. That allows us to test two branches with migrations
and allows us to properly roll back migrations not in master.