### PR TITLE
Add branch option to perf check

### DIFF
--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -18,6 +18,7 @@ class PerfCheck
     @options = OpenStruct.new(
       number_of_requests: 20,
       reference: 'master',
+      branch: nil,
       cookie: nil,
       headers: {},
       http_statuses: [200],

--- a/lib/perf_check/config.rb
+++ b/lib/perf_check/config.rb
@@ -24,6 +24,11 @@ class PerfCheck
         options.reference = commit
       end
 
+      opts.on('--branch COMMIT', '-branch',
+              'Set the current branch to benchmark against (defaults to master)') do |branch|
+        options.branch = branch
+      end
+
       opts.on('--quick', '-q',
               '20 requests just on this branch (no comparison with master)') do
         options.reference = nil

--- a/lib/perf_check/config.rb
+++ b/lib/perf_check/config.rb
@@ -25,7 +25,7 @@ class PerfCheck
       end
 
       opts.on('--branch COMMIT', '-branch',
-              'Set the current branch to benchmark against (defaults to master)') do |branch|
+              'Set the current branch to benchmark against (defaults to the branch you currently have checked out)') do |branch|
         options.branch = branch
       end
 

--- a/lib/perf_check/git.rb
+++ b/lib/perf_check/git.rb
@@ -15,7 +15,7 @@ class PerfCheck
       @git_root = perf_check.app_root
       @logger = perf_check.logger
 
-      @current_branch = exec "git rev-parse --abbrev-ref HEAD"
+      @current_branch = perf_check.options.branch || exec("git rev-parse --abbrev-ref HEAD")
     end
 
     def checkout(branch, bundle_after_checkout: true, hard_reset: false)

--- a/spec/perf_check/git_spec.rb
+++ b/spec/perf_check/git_spec.rb
@@ -23,13 +23,22 @@ RSpec.describe PerfCheck::Git do
     FileUtils.rm_rf(File.join(__dir__,'../../tmp/spec/'))
   end
 
-  let(:perf_check){ double(app_root: repo, logger: Logger.new('/dev/null')) }
+  let(:perf_check){ double(app_root: repo, logger: Logger.new('/dev/null'), options: OpenStruct.new(branch: nil)) }
   let(:git){ PerfCheck::Git.new(perf_check) }
+
+  let(:perf_check_with_branch_option){ double(app_root: repo, logger: Logger.new('/dev/null'), options: OpenStruct.new(branch: 'specified-branch')) }
+  let(:git_with_branch_option){ PerfCheck::Git.new(perf_check_with_branch_option) }
+
 
   describe "#initialize" do
     it "should find the current branch checked out in perf_check.app_root" do
       expect(git.current_branch).to eq("master")
     end
+
+    it "should find the branch specified in --branch if the option is set" do
+      expect(git_with_branch_option.current_branch).to eq("specified-branch")
+    end
+
 
     it "should initialize #logger to perf_check.logger" do
       expect(git.logger).to eq(perf_check.logger)

--- a/spec/perf_check/git_spec.rb
+++ b/spec/perf_check/git_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe PerfCheck::Git do
       expect(git_with_branch_option.current_branch).to eq("specified-branch")
     end
 
-
     it "should initialize #logger to perf_check.logger" do
       expect(git.logger).to eq(perf_check.logger)
     end


### PR DESCRIPTION
This adds the ability to pass in a different comparison branch (currently it defaults to selecting whatever branch you have checked out `git rev-parse --abbrev-ref HEAD` ). For eg. I want to compare two branches `perf_check --branch feature_1 -r feature_2` but I have the master branch checked out