### PR TITLE
Use PerfCheck logger when logging from PerfCheck::Git

### DIFF
--- a/lib/perf_check/git.rb
+++ b/lib/perf_check/git.rb
@@ -8,14 +8,15 @@ class PerfCheck
     class BundleError < Exception; end
 
     attr_reader :perf_check, :git_root, :current_branch
-    attr_accessor :logger
 
     def initialize(perf_check)
       @perf_check = perf_check
       @git_root = perf_check.app_root
-      @logger = perf_check.logger
-
       @current_branch = perf_check.options.branch || exec("git rev-parse --abbrev-ref HEAD")
+    end
+
+    def logger
+      @perf_check.logger
     end
 
     def checkout(branch, bundle_after_checkout: true, hard_reset: false)

--- a/spec/perf_check/git_spec.rb
+++ b/spec/perf_check/git_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe PerfCheck::Git do
   let(:perf_check_with_branch_option){ double(app_root: repo, logger: Logger.new('/dev/null'), options: OpenStruct.new(branch: 'specified-branch')) }
   let(:git_with_branch_option){ PerfCheck::Git.new(perf_check_with_branch_option) }
 
+  it "allows logger to change on perf_check" do
+    perf_check = PerfCheck.new(repo)
+    git = PerfCheck::Git.new(perf_check)
+    expect(git.logger).to eq(perf_check.logger)
+    perf_check.logger = Logger.new(nil)
+    expect(git.logger).to eq(perf_check.logger)
+  end
 
   describe "#initialize" do
     it "should find the current branch checked out in perf_check.app_root" do


### PR DESCRIPTION
Don't store a local copy of the logger on `PerfCheck::Git`.

Closes #37.