### PR TITLE
Adds switch to spawn rails server in a new bash process

### DIFF
--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -25,12 +25,15 @@ class PerfCheck
       http_statuses: [200],
       verify_no_diff: false,
       diff: false,
-      diff_options: ['-U3',
-                     '--ignore-matching-lines=/mini-profiler-resources/includes.js'],
+      diff_options: [
+        '-U3',
+        '--ignore-matching-lines=/mini-profiler-resources/includes.js'
+      ],
       brief: false,
       caching: true,
       json: false,
       hard_reset: false,
+      spawn_shell: false,
       environment: 'development'
     )
 

--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -1,10 +1,11 @@
-require 'net/http'
+require 'benchmark'
+require 'bundler'
+require 'colorize'
 require 'digest'
 require 'fileutils'
-require 'benchmark'
-require 'ostruct'
-require 'colorize'
 require 'logger'
+require 'net/http'
+require 'ostruct'
 
 class PerfCheck
   class Exception < ::Exception; end

--- a/lib/perf_check/config.rb
+++ b/lib/perf_check/config.rb
@@ -51,10 +51,14 @@ class PerfCheck
 
       opts.separator "\nRails environment"
 
-      opts.on('--deployment','Use git fetch/reset instead of the safe/friendly checkout') do
+      opts.on('--deployment', 'Use git fetch/reset instead of the safe/friendly checkout') do
         options.hard_reset = true
       end
 
+      opts.on('--shell', 'Use shell (i.e. bash) to start a fresh environment when running the target application.') do
+        options.spawn_shell = true
+      end
+      
       opts.on('--environment', '-e',
         'Change the rails environment we are profiling. Defaults to development') do |env|
         options.environment = env

--- a/lib/perf_check/server.rb
+++ b/lib/perf_check/server.rb
@@ -101,27 +101,8 @@ class PerfCheck
     end
 
     def start
-      perf_check_args = { 'PERF_CHECK' => '1', 'DISABLE_SPRING' => '1' }
-      if perf_check.options.verify_no_diff
-        perf_check_args['PERF_CHECK_VERIFICATION'] = '1'
-      end
-      unless perf_check.options.caching
-        perf_check_args['PERF_CHECK_NOCACHING'] = '1'
-      end
-
-      app_root = Shellwords.shellescape(perf_check.app_root)
-      Bundler.with_original_env do
-        Dir.chdir app_root do
-          pid = Process.spawn(
-            perf_check_args,
-            "bundle exec rails server -b #{host} -d -p #{port} -e #{environment}",
-            [:out] => '/dev/null'
-          )
-          Process.wait pid
-        end
-      end
+      Process.wait(spawn)
       sleep(1.5)
-
       @running = true
     end
 
@@ -158,6 +139,40 @@ class PerfCheck
 
     def pidfile
       @pidfile ||= "#{perf_check.app_root}/tmp/pids/server.pid"
+    end
+
+    def environment_variables
+      variables = { 'PERF_CHECK' => '1', 'DISABLE_SPRING' => '1' }
+      if perf_check.options.verify_no_diff
+        variables['PERF_CHECK_VERIFICATION'] = '1'
+      end
+      unless perf_check.options.caching
+        variables['PERF_CHECK_NOCACHING'] = '1'
+      end
+      variables
+    end
+
+    def rails_server_command
+      "bundle exec rails server -b #{host} -d -p #{port} -e #{environment}"
+    end
+
+    def spawn
+      if perf_check.options.spawn_shell
+        Process.spawn(
+          environment_variables.merge('HOME' => ENV['HOME']),
+          "bash -l -c \"#{rails_server_command}\"",
+          chdir: perf_check.app_root,
+          unsetenv_others: true
+        )
+      else
+        Bundler.with_original_env do
+          Process.spawn(
+            environment_variables,
+            rails_server_command,
+            chdir: perf_check.app_root
+          )
+        end
+      end
     end
   end
 end

--- a/spec/perf_check/config_spec.rb
+++ b/spec/perf_check/config_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+RSpec.describe PerfCheck do
+  let(:perf_check) { PerfCheck.new('test_app') }
+  context "option parser" do
+    it "allows the --shell option to turn on the spawn_shell option" do
+      expect(perf_check.options.spawn_shell).to eq(false)
+      perf_check.parse_arguments(%w(--shell))
+      expect(perf_check.options.spawn_shell).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
Use a new `bash` process when starting the rails server when `--shell` switch is set.

```
perf_check --shell
```

Closes #39.