### PR TITLE
Reverse defaults for reference and branch options

### DIFF
--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -18,8 +18,8 @@ class PerfCheck
     @app_root = app_root
     @options = OpenStruct.new(
       number_of_requests: 20,
-      reference: 'master',
-      branch: nil,
+      reference: nil,
+      branch: 'master',
       cookie: nil,
       headers: {},
       http_statuses: [200],

--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -74,6 +74,8 @@ class PerfCheck
   end
 
   def run
+    git.stash_if_needed
+    git.checkout(options.branch, bundle_after_checkout: true, hard_reset: options.hard_reset)
     begin
       if options.compare_paths?
         raise "Must have two paths" if test_cases.count != 2
@@ -84,7 +86,6 @@ class PerfCheck
           git.stash_if_needed
           git.checkout(options.reference, bundle_after_checkout: true, hard_reset: options.hard_reset)
           test_cases.each{ |x| x.switch_to_reference_context }
-
           profile_requests
         end
       end

--- a/spec/perf_check/config_spec.rb
+++ b/spec/perf_check/config_spec.rb
@@ -2,11 +2,25 @@ require 'spec_helper'
 
 RSpec.describe PerfCheck do
   let(:perf_check) { PerfCheck.new('test_app') }
+
+  context "defaults" do
+    it "only tests against master" do
+      expect(perf_check.options.branch).to eq('master')
+      expect(perf_check.options.reference).to be_nil
+    end
+  end
+
   context "option parser" do
     it "allows the --shell option to turn on the spawn_shell option" do
       expect(perf_check.options.spawn_shell).to eq(false)
       perf_check.parse_arguments(%w(--shell))
       expect(perf_check.options.spawn_shell).to eq(true)
+    end
+
+    it "allows the --reference option to change the reference branch" do
+      expect(perf_check.options.reference).to be_nil
+      perf_check.parse_arguments(%w(--reference slower))
+      expect(perf_check.options.reference).to eq('slower')
     end
   end
 end


### PR DESCRIPTION
I totally misunderstood how perf_check was supposed to work and assumed that the --branch switch was used to set the branch you are testing against.