### PR TITLE
Add automated mode option and switch to branch

### DIFF
--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -113,14 +113,20 @@ class PerfCheck
 
   def compare_paths
     raise "Must have two paths" if test_cases.count != 2
+    ensure_branch
     profile_compare_paths_requests
   end
 
   def compare_branches
+    ensure_branch
     profile_requests
     if options.reference
       git.stash_if_needed
-      git.checkout(options.reference, bundle_after_checkout: true, hard_reset: options.automated)
+      git.checkout(
+        options.reference,
+        bundle_after_checkout: true,
+        hard_reset: options.automated
+      )
       test_cases.each(&:switch_to_reference_context)
       profile_requests
     end
@@ -180,11 +186,7 @@ class PerfCheck
 
   def cleanup_and_report
     server.exit
-    if options.reference
-      git.checkout(git.initial_branch, bundle_after_checkout: true)
-      git.pop if git.stashed?
-    end
-
+    cleanup_git
     callbacks = {}
 
     if $!
@@ -210,6 +212,26 @@ class PerfCheck
         fail_with: BundleError
       )
     end
+  end
+
+  private
+
+  def ensure_branch
+    return unless options.automated && options.branch
+
+    git.checkout(options.branch, bundle_after_checkout: true, hard_reset: true)
+  end
+
+  def cleanup_git
+    return if options.automated
+
+    # Switch back to the initial branch unless we're already on it.
+    if git.initial_branch != git.detect_current_branch  
+      git.checkout(git.initial_branch, bundle_after_checkout: false)
+    end
+
+    # Restore any stashed changes
+    git.pop if git.stashed?
   end
 end
 

--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -34,6 +34,9 @@ class PerfCheck
       brief: false,
       caching: true,
       json: false,
+      # Automated is set to true when PerfCheck runs in a CI-like managed
+      # environment.
+      automated: false,
       hard_reset: false,
       spawn_shell: false,
       environment: 'development',

--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -181,7 +181,7 @@ class PerfCheck
   def cleanup_and_report
     server.exit
     if options.reference
-      git.checkout(git.current_branch, bundle_after_checkout: true)
+      git.checkout(git.initial_branch, bundle_after_checkout: true)
       git.pop if git.stashed?
     end
 

--- a/lib/perf_check.rb
+++ b/lib/perf_check.rb
@@ -37,7 +37,6 @@ class PerfCheck
       # Automated is set to true when PerfCheck runs in a CI-like managed
       # environment.
       automated: false,
-      hard_reset: false,
       spawn_shell: false,
       environment: 'development',
       verbose: false
@@ -121,7 +120,7 @@ class PerfCheck
     profile_requests
     if options.reference
       git.stash_if_needed
-      git.checkout(options.reference, bundle_after_checkout: true, hard_reset: options.hard_reset)
+      git.checkout(options.reference, bundle_after_checkout: true, hard_reset: options.automated)
       test_cases.each(&:switch_to_reference_context)
       profile_requests
     end

--- a/lib/perf_check/callbacks.rb
+++ b/lib/perf_check/callbacks.rb
@@ -24,13 +24,12 @@ class PerfCheck
     ]
   end
 
-
   def trigger_before_start_callbacks(test_case)
     before_start_callbacks.each{ |f| f.call(self, test_case) }
   end
 
   def trigger_when_finished_callbacks(data={})
-    data = data.merge(:current_branch => git.current_branch)
+    data = data.merge(current_branch: git.detect_current_branch)
     results = OpenStruct.new(data)
     if test_cases.size == 1
       results.current_latency = test_cases.first.this_latency

--- a/lib/perf_check/callbacks.rb
+++ b/lib/perf_check/callbacks.rb
@@ -1,5 +1,10 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 class PerfCheck
+  BANNER = "PERRRRF CHERRRK! Grab a ☕️ and don't touch your working tree " \
+           "(we automate git)"
+  BANNER_BORDER = '=' * BANNER.length
+
   def when_finished(&block)
     @when_finished_callbacks ||= []
     @when_finished_callbacks << block
@@ -17,15 +22,15 @@ class PerfCheck
   def before_start_callbacks
     (@before_start_callbacks || []) + [
       proc { |perf_check|
-        perf_check.logger.info("=" * 77)
-        perf_check.logger.info("PERRRRF CHERRRK! Grab a ☕️  and don't touch your working tree (we automate git)")
-        perf_check.logger.info("=" * 77)
+        perf_check.logger.info(BANNER_BORDER)
+        perf_check.logger.info(BANNER)
+        perf_check.logger.info(BANNER_BORDER)
       }
     ]
   end
 
   def trigger_before_start_callbacks(test_case)
-    before_start_callbacks.each{ |f| f.call(self, test_case) }
+    before_start_callbacks.each { |f| f.call(self, test_case) }
   end
 
   def trigger_when_finished_callbacks(data={})

--- a/lib/perf_check/config.rb
+++ b/lib/perf_check/config.rb
@@ -52,7 +52,7 @@ class PerfCheck
       opts.separator "\nRails environment"
 
       opts.on('--deployment', 'Use git fetch/reset instead of the safe/friendly checkout') do
-        options.hard_reset = true
+        options.automated = true
       end
 
       opts.on('--shell', 'Use shell (i.e. bash) to start a fresh environment when running the target application.') do

--- a/lib/perf_check/git.rb
+++ b/lib/perf_check/git.rb
@@ -6,12 +6,13 @@ class PerfCheck
     class StashError < Exception; end
     class StashPopError < Exception; end
 
-    attr_reader :perf_check, :git_root, :current_branch
+    attr_reader :perf_check, :git_root
+    attr_reader :initial_branch
 
     def initialize(perf_check)
       @perf_check = perf_check
       @git_root = perf_check.app_root
-      @current_branch = perf_check.options.branch || detect_current_branch
+      @initial_branch = perf_check.options.branch || detect_current_branch
     end
 
     def logger

--- a/lib/perf_check/git.rb
+++ b/lib/perf_check/git.rb
@@ -12,7 +12,7 @@ class PerfCheck
     def initialize(perf_check)
       @perf_check = perf_check
       @git_root = perf_check.app_root
-      @initial_branch = perf_check.options.branch || detect_current_branch
+      @initial_branch = detect_current_branch
     end
 
     def logger

--- a/lib/perf_check/git.rb
+++ b/lib/perf_check/git.rb
@@ -65,6 +65,16 @@ class PerfCheck
       PerfCheck.execute('git checkout db')
     end
 
+    def detect_current_branch
+      branch = PerfCheck.execute('git rev-parse --abbrev-ref=loose HEAD').strip
+      return branch unless branch == 'HEAD'
+
+      # When the current ref is abbreviated to HEAD it's pretty useless because
+      # it will not allow us to reliably switch to this ref at a later time. The
+      # solution is to not abbreviate.
+      PerfCheck.execute('git rev-parse HEAD').strip
+    end
+
     private
 
     def checkout_command(branch, hard_reset: false)
@@ -73,10 +83,6 @@ class PerfCheck
       else
         "git checkout #{branch}"
       end
-    end
-
-    def detect_current_branch
-      PerfCheck.execute('git rev-parse --abbrev-ref HEAD').strip
     end
 
     def update_submodules

--- a/spec/perf_check/config_spec.rb
+++ b/spec/perf_check/config_spec.rb
@@ -4,6 +4,11 @@ RSpec.describe PerfCheck do
   let(:perf_check) { PerfCheck.new('test_app') }
 
   context "option parser" do
+    it "allows the --deployment options to turn on automated mode" do
+      perf_check.parse_arguments(%w(--deployment))
+      expect(perf_check.options.automated).to eq(true)
+    end
+
     it "allows the --shell option to turn on the spawn_shell option" do
       expect(perf_check.options.spawn_shell).to eq(false)
       perf_check.parse_arguments(%w(--shell))

--- a/spec/perf_check/git_spec.rb
+++ b/spec/perf_check/git_spec.rb
@@ -34,12 +34,6 @@ RSpec.describe PerfCheck::Git do
         expect(git.initial_branch).to eq('master')
       end
 
-      it 'finds the branch specified in --branch if the option is set' do
-        perf_check.options.branch = 'specified-branch'
-        git = PerfCheck::Git.new(perf_check)
-        expect(git.initial_branch).to eq('specified-branch')
-      end
-
       it 'initializes #logger to perf_check.logger' do
         git = PerfCheck::Git.new(perf_check)
         expect(git.logger).to eq(perf_check.logger)

--- a/spec/perf_check/git_spec.rb
+++ b/spec/perf_check/git_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe PerfCheck::Git do
     end
     let(:feature_branch) { 'perf-check' }
     let(:non_existent_branch){ 'non-existent' }
+    let(:commit) { 'fe704dd6d1fa37d8d432b6d07c1ce261a93ca11f' }
 
     describe 'when initializing' do
       it 'finds the initial branch checked out in perf_check.app_root' do
@@ -42,6 +43,22 @@ RSpec.describe PerfCheck::Git do
       it 'initializes #logger to perf_check.logger' do
         git = PerfCheck::Git.new(perf_check)
         expect(git.logger).to eq(perf_check.logger)
+      end
+
+      it 'returns the real actual current branch or commit' do
+        git = PerfCheck::Git.new(perf_check)
+        expect(git.detect_current_branch).to eq('master')
+
+        git.checkout('HEAD~1')
+        expect(git.detect_current_branch).to eq(
+          'fe704dd6d1fa37d8d432b6d07c1ce261a93ca11f'
+        )
+
+        git.checkout(feature_branch)
+        expect(git.detect_current_branch).to eq(feature_branch)
+
+        git.checkout(commit)
+        expect(git.detect_current_branch).to eq(commit)
       end
     end
 

--- a/spec/perf_check/git_spec.rb
+++ b/spec/perf_check/git_spec.rb
@@ -28,15 +28,15 @@ RSpec.describe PerfCheck::Git do
     let(:non_existent_branch){ 'non-existent' }
 
     describe 'when initializing' do
-      it 'finds the current branch checked out in perf_check.app_root' do
+      it 'finds the initial branch checked out in perf_check.app_root' do
         git = PerfCheck::Git.new(perf_check)
-        expect(git.current_branch).to eq('master')
+        expect(git.initial_branch).to eq('master')
       end
 
       it 'finds the branch specified in --branch if the option is set' do
         perf_check.options.branch = 'specified-branch'
         git = PerfCheck::Git.new(perf_check)
-        expect(git.current_branch).to eq('specified-branch')
+        expect(git.initial_branch).to eq('specified-branch')
       end
 
       it 'initializes #logger to perf_check.logger' do

--- a/spec/perf_check_spec.rb
+++ b/spec/perf_check_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe PerfCheck do
           --branch UE-3965/faster    /4/co/cu/15
         ]
       )
-      expect(perf_check.options.hard_reset).to eq(true)
+      expect(perf_check.options.automated).to eq(true)
       expect(perf_check.options.spawn_shell).to eq(true)
       expect(perf_check.options.number_of_requests).to eq(2)
       expect(perf_check.options.branch).to eq('UE-3965/faster')

--- a/spec/perf_check_spec.rb
+++ b/spec/perf_check_spec.rb
@@ -19,6 +19,19 @@ RSpec.describe PerfCheck do
     perf_check
   end
 
+  describe 'defaults' do
+    let(:options) { perf_check.options }
+
+    it 'is not automated by default' do
+      expect(options.automated).to eq(false)
+    end
+
+    it 'changes to running in automated mode' do
+      options.automated = true
+      expect(options.automated).to eq(true)
+    end
+  end
+
   describe 'option parser' do
     it 'parses the environment' do
       perf_check.parse_arguments(%w[--environment staging])

--- a/spec/perf_check_spec.rb
+++ b/spec/perf_check_spec.rb
@@ -295,13 +295,60 @@ RSpec.describe PerfCheck do
       perf_check.options.spawn_shell = true
       perf_check
     end
+    let(:git) { perf_check.git }
 
     it 'benchmarks the specified branch and compares to master' do
+      expect(git.detect_current_branch).to eq('master')
+
       perf_check.parse_arguments(%w[--branch slower /])
       perf_check.run
+
       expect(output.string).to include('☕️')
       expect(output.string).to include('Benchmarking /')
+      expect(output.string).to_not include('Checking out slower and bundling')
       expect(output.string).to include('Checking out master and bundling')
+
+      expect(git.detect_current_branch).to eq(git.initial_branch)
+    end
+
+    it 'benchmarks the specified branch and compares to master automated' do
+      expect(git.detect_current_branch).to eq('master')
+
+      perf_check.parse_arguments(%w[--deployment --branch slower /])
+      perf_check.run
+
+      expect(output.string).to include('☕️')
+      expect(output.string).to include('Benchmarking /')
+      expect(output.string).to include('Checking out slower and bundling')
+      expect(output.string).to include('Checking out master and bundling')
+
+      expect(git.detect_current_branch).to eq(git.initial_branch)
+    end
+
+    it 'benchmarks two paths' do
+      expect(git.detect_current_branch).to eq('master')
+
+      perf_check.parse_arguments(%w[--compare-paths / /])
+      perf_check.run
+
+      expect(output.string).to include('☕️')
+      expect(output.string).to include('Benchmarking /')
+      expect(output.string).to_not include('Checking out')
+
+      expect(git.detect_current_branch).to eq(git.initial_branch)
+    end
+
+    it 'benchmarks two paths automated' do
+      expect(git.detect_current_branch).to eq('master')
+
+      perf_check.parse_arguments(%w[--deployment --compare-paths / /])
+      perf_check.run
+
+      expect(output.string).to include('☕️')
+      expect(output.string).to include('Benchmarking /')
+      expect(output.string).to_not include('Checking out')
+
+      expect(git.detect_current_branch).to eq(git.initial_branch)
     end
 
     it 'does not break when there is no config/perf_check.rb' do


### PR DESCRIPTION
Switch to the test branch when running in automated mode so the first benchmarks run against the correct branch.

Also fixes a problem with returning git state after begin on HEAD initially.

Also also removes a space after the coffee glyph in the PerfCheck banner.

Also also also no longer run bundler when switching back to the initial branch.

References #46.
