### PR TITLE
Always execute in the app root

### DIFF
--- a/lib/perf_check/git.rb
+++ b/lib/perf_check/git.rb
@@ -1,5 +1,3 @@
-require 'shellwords'
-
 class PerfCheck
   class Git
     class NoSuchBranch < Exception; end

--- a/lib/perf_check/git.rb
+++ b/lib/perf_check/git.rb
@@ -19,18 +19,18 @@ class PerfCheck
 
     def checkout(branch, bundle_after_checkout: true, hard_reset: false)
       logger.info("Checking out #{branch} and bundling... ")
-      PerfCheck.execute(
+      perf_check.execute(
         checkout_command(branch, hard_reset: hard_reset),
         fail_with: NoSuchBranch
       )
       update_submodules
-      PerfCheck.bundle if bundle_after_checkout
+      perf_check.bundle if bundle_after_checkout
     end
 
     def stash_if_needed
       if anything_to_stash?
         logger.info("Stashing your changes... ")
-        PerfCheck.execute('git stash -q >/dev/null', fail_with: StashError)
+        perf_check.execute('git stash -q >/dev/null', fail_with: StashError)
         @stashed = true
       else
         false
@@ -42,14 +42,14 @@ class PerfCheck
     end
 
     def anything_to_stash?
-      git_stash = PerfCheck.execute('git diff')
-      git_stash << PerfCheck.execute('git diff --staged')
+      git_stash = perf_check.execute('git diff')
+      git_stash << perf_check.execute('git diff --staged')
       !git_stash.empty?
     end
 
     def pop
       logger.info("Git stash applying...")
-      PerfCheck.execute('git stash pop -q', fail_with: StashPopError)
+      perf_check.execute('git stash pop -q', fail_with: StashPopError)
       @stashed = false
     end
 
@@ -60,17 +60,17 @@ class PerfCheck
     end
 
     def clean_db
-      PerfCheck.execute('git checkout db')
+      perf_check.execute('git checkout db')
     end
 
     def detect_current_branch
-      branch = PerfCheck.execute('git rev-parse --abbrev-ref=loose HEAD').strip
+      branch = perf_check.execute('git rev-parse --abbrev-ref=loose HEAD').strip
       return branch unless branch == 'HEAD'
 
       # When the current ref is abbreviated to HEAD it's pretty useless because
       # it will not allow us to reliably switch to this ref at a later time. The
       # solution is to not abbreviate.
-      PerfCheck.execute('git rev-parse HEAD').strip
+      perf_check.execute('git rev-parse HEAD').strip
     end
 
     private
@@ -84,13 +84,13 @@ class PerfCheck
     end
 
     def update_submodules
-      PerfCheck.execute('git submodule update')
+      perf_check.execute('git submodule update')
     end
 
     def current_migrations_not_on_master
       return [] unless File.exist?('db/migrate')
 
-      PerfCheck.execute(
+      perf_check.execute(
         'git diff master --name-only --diff-filter=A db/migrate/'
       ).split.reverse
     end

--- a/lib/perf_check/server.rb
+++ b/lib/perf_check/server.rb
@@ -48,7 +48,7 @@ class PerfCheck
     def mem
       return 0.0 unless pid
 
-      PerfCheck.execute('ps', '-o', 'rss=', '-p', pid.to_s).strip.to_f / 1024
+      perf_check.execute('ps', '-o', 'rss=', '-p', pid.to_s).strip.to_f / 1024
     end
 
     def prepare_to_profile

--- a/spec/perf_check/config_spec.rb
+++ b/spec/perf_check/config_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe PerfCheck do
-  let(:perf_check) { PerfCheck.new('test_app') }
+  let(:perf_check) { PerfCheck.new(minimal_app_dir) }
 
   context "option parser" do
     it "allows the -b option to select the experiment branch" do

--- a/spec/perf_check/server_spec.rb
+++ b/spec/perf_check/server_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe PerfCheck::Server do
   let(:output) { StringIO.new }
   let(:perf_check) do
-    perf_check = PerfCheck.new(Dir.pwd)
+    perf_check = PerfCheck.new(minimal_app_dir)
     perf_check.logger = Logger.new(output)
     perf_check
   end

--- a/spec/perf_check_spec.rb
+++ b/spec/perf_check_spec.rb
@@ -241,22 +241,21 @@ RSpec.describe PerfCheck do
 end
 
 RSpec.describe PerfCheck do
+  let(:perf_check) { PerfCheck.new(minimal_app_dir) }
+
   it 'expands the app dir' do
-    perf_check = PerfCheck.new('app')
-    expect(perf_check.app_root).to eq(
-      File.expand_path('../app', __dir__)
-    )
+    app_dir = minimal_app_dir + '/../' + minimal_app_dir.split('/').last
+    perf_check = PerfCheck.new(app_dir)
+    expect(perf_check.app_root).to eq(minimal_app_dir)
   end
 
   it 'returns the path to its config script in the target application' do
-    perf_check = PerfCheck.new('app')
     expect(perf_check.config_path).to eq(
-      File.expand_path('../app/config/perf_check.rb', __dir__)
+      File.join(minimal_app_dir, 'config/perf_check.rb')
     )
   end
 
   it 'adds a test case with a request path' do
-    perf_check = PerfCheck.new('app')
     expect(perf_check.test_cases.size).to be_zero
 
     request_path = '/books/42/authors?q=he'
@@ -271,12 +270,10 @@ RSpec.describe PerfCheck do
   end
 
   it 'uses the info log level by default' do
-    perf_check = PerfCheck.new('app')
     expect(perf_check.logger.level).to eq(Logger::INFO)
   end
 
   it 'sets the log level to debug when running in verbose mode' do
-    perf_check = PerfCheck.new('app')
     perf_check.options.verbose = true
     expect(perf_check.logger.level).to eq(Logger::DEBUG)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,10 @@ RSpec.configure do |config|
   config.include Support::Commands
   config.include Support::Paths
 
+  config.after(:suite) do
+    FileUtils.rm_rf(Support::Apps.minimal_app_dir)
+  end
+
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4, it's included here for
     # forward compatibility.

--- a/spec/support/apps.rb
+++ b/spec/support/apps.rb
@@ -3,6 +3,67 @@
 module Support
   # Helpers to prepare app directories for integration testing.
   module Apps
+    # Returns the directory that holds all the app bundles.
+    def self.bundle_dir
+      File.expand_path('../bundles', __dir__)
+    end
+
+    # Returns a path to a tarball for the specified bundle name.
+    def self.app_bundle_path(name)
+      File.join(bundle_dir, "#{name}.tar.bz2")
+    end
+
+    def self.minimal_app_dir
+      minimal_app.app_dir
+    end
+
+    def self.minimal_app
+      @minimal_app ||= begin
+        app = PerfCheck::App.new(
+          bundle_path: app_bundle_path('minimal'),
+          app_dir: Dir.mktmpdir('perf-check-minimal')
+        )
+        app.unpack
+        app
+      end
+    end
+
+    def minimal_app_dir
+      Support::Apps.minimal_app_dir
+    end
+
+    def app_bundle_path(name)
+      Support::Apps.app_bundle_path(name)
+    end
+
+    # Unpacks an app, changes directory to that app, and calls the block.
+    def using_app(name, &block)
+      using_tmpdir do |app_dir|
+        PerfCheck::App.new(
+          bundle_path: Support::Apps.app_bundle_path(name),
+          app_dir: app_dir
+        ).unpack
+        Dir.chdir(app_dir, &block)
+      end
+    end
+
+    # Because apps are unpacked to a temporary directory we need to symlink
+    # the perf_check project root from the application directory in order to
+    # use it easily from the Gemfile.
+    def link_perf_check
+      execute('ln', '-s', perf_check_project_root, 'perf_check')
+    end
+
+    def run_bundle_install
+      # Use the --frozen option to prevent the test suite from writing a new
+      # Gemfile.lock.
+      bundle 'install', '--frozen', '--retry', '3', '--jobs', '3'
+    end
+
+    def run_db_setup
+      bundle 'exec', 'rake', 'db:setup'
+    end
+
     # Prints a lot of stuff to STDOUT so we can see if the isolated app was
     # unpacked an functioning properly.
     def inspect_app
@@ -29,48 +90,6 @@ module Support
         puts
         puts File.read(filename)
       end
-    end
-
-    # Returns the directory that holds all the app bundles.
-    def bundle_dir
-      File.expand_path('../bundles', __dir__)
-    end
-
-    # Returns a path to a tarball for the specified bundle name.
-    def app_bundle_path(name)
-      File.join(bundle_dir, "#{name}.tar.bz2")
-    end
-
-    # Unpacks an app, changes directory to that app, and calls the block.
-    def using_app(name, &block)
-      using_tmpdir do |app_dir|
-        PerfCheck::App.new(
-          bundle_path: app_bundle_path(name),
-          app_dir: app_dir
-        ).unpack
-        Dir.chdir(app_dir, &block)
-      end
-    end
-
-    def perf_check_project_root
-      File.expand_path('../../', __dir__)
-    end
-
-    # Because apps are unpacked to a temporary directory we need to symlink
-    # the perf_check project root from the application directory in order to
-    # use it easily from the Gemfile.
-    def link_perf_check
-      execute('ln', '-s', perf_check_project_root, 'perf_check')
-    end
-
-    def run_bundle_install
-      # Use the --frozen option to prevent the test suite from writing a new
-      # Gemfile.lock.
-      bundle 'install', '--frozen', '--retry', '3', '--jobs', '3'
-    end
-
-    def run_db_setup
-      bundle 'exec', 'rake', 'db:setup'
     end
   end
 end

--- a/spec/support/paths.rb
+++ b/spec/support/paths.rb
@@ -10,5 +10,10 @@ module Support
     def using_tmpdir(&block)
       Dir.mktmpdir('perf-check', &block)
     end
+
+    # Returns the root directory if the source code.
+    def perf_check_project_root
+      File.expand_path('../../', __dir__)
+    end
   end
 end


### PR DESCRIPTION
Perform all commands through `PerfCheck#execute` so we can ensure they always run in a consistent way in the app root. This resolves a problem when `bundle` was executed in the wrong directory when running in a new shell because the current working directory was reset.

Closes #56.